### PR TITLE
Remove extra whitespace from <a href> tags in DOCX

### DIFF
--- a/lib/htmltoword/xslt/links.xslt
+++ b/lib/htmltoword/xslt/links.xslt
@@ -27,9 +27,7 @@
           <w:color w:val="000080"/>
           <w:u w:val="single"/>
         </w:rPr>
-        <w:t xml:space="preserve">
-          <xsl:value-of select="."/>
-        </w:t>
+        <w:t xml:space="preserve"><xsl:value-of select="."/></w:t>
       </w:r>
     </w:hyperlink>
   </xsl:template>


### PR DESCRIPTION
This caused extra spaces to appear within the link text in <a href> tags, resulting in display like this: __________Link_Text________
Fixes DMPRoadmap/roadmap#1185